### PR TITLE
The app size fixed (fullscreen disable)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,6 @@ void main() {
   final member = MemberInformation.allItems();
 
   WidgetsFlutterBinding.ensureInitialized();
-  SystemChrome.setEnabledSystemUIOverlays([]);
 
   return runApp(MaterialApp(
     theme: ThemeData(


### PR DESCRIPTION
The problem of the height that the app was presenting was that it was on fullscreen mode, so that it could hide the status bar and the system's buttons at the bottom. Since there is no need of hidding them, the fullscreen was removed.